### PR TITLE
fixed visibility bug for user email display in  dark mode

### DIFF
--- a/packages/web/src/components/Home/Home.jsx
+++ b/packages/web/src/components/Home/Home.jsx
@@ -450,11 +450,11 @@ export default function Home() {
 
                     {/* User Emblem Dropdown */}
                     <MenuList zIndex={10000}>
-                      <MenuItem _focus={{ bg: "white" }}>
+                      <MenuItem>
                         <Image
                           boxSize="1.2rem"
                           src={userlogo}
-                          alt="logoutbutton"
+                          alt="user email"
                           mr="12px"
                         />
                         {user?.email}


### PR DESCRIPTION
Just had to remove the _focus prop. It was initially setting the background of the user email menu item as white.