### PR TITLE
57-dropzone-images

### DIFF
--- a/packages/web/src/components/CreateModal/CreateModal.jsx
+++ b/packages/web/src/components/CreateModal/CreateModal.jsx
@@ -83,12 +83,34 @@ export default function CreateModal({
   );
 
   // Define the JSX for the uploaded image
-  const uploadedImage = (
-    <Image
-      width={{ md: "40%", base: "80%" }}
-      src={uploadImg ? uploadImg : img_placeholder}
-    />
-  );
+  const uploadedImage = uploadImg == ""
+    ? null
+    : (
+      <Flex direction="column" align="center" position="relative">
+        <Image
+          width={{ md: "40%", base: "80%" }}
+          src={uploadImg ? uploadImg : img_placeholder}
+        />
+        {uploadImg && (
+          <Button
+            size="sm"
+            colorScheme="red"
+            position="absolute"
+            top={2}
+            right={2}
+            onClick={() => {
+              setUploadImg("");
+              setNewAddedItem((prev) => ({
+                ...prev,
+                image: "",
+              }));
+            }}
+          >
+            ✕
+          </Button>
+        )}
+      </Flex>
+    );
 
   // Define the callback function to increment the active step count
   const handleStepIncrement = useCallback(() => {
@@ -316,7 +338,6 @@ export default function CreateModal({
                 {/* fourth step */}
                 {activeStep === 3 && (
                   <ImageInput
-                    handleItemDateChange={handleItemDateChange}
                     handleItemImageChange={handleItemImageChange}
                     isLoading={isLoading}
                     loadingAnimation={loadingAnimation}

--- a/packages/web/src/components/CreateModal/CreateModal.jsx
+++ b/packages/web/src/components/CreateModal/CreateModal.jsx
@@ -83,12 +83,12 @@ export default function CreateModal({
   );
 
   // Define the JSX for the uploaded image
-  const uploadedImage = uploadImg == ""
-    ? null
-    : (
+  const uploadedImage =
+    uploadImg == "" ? null : (
       <Flex direction="column" align="center" position="relative">
         <Image
-          width={{ md: "40%", base: "80%" }}
+          // width={{ md: "lg", base: "80%" }}
+          height={{ md: "md", base: "70%" }}
           src={uploadImg ? uploadImg : img_placeholder}
         />
         {uploadImg && (
@@ -96,6 +96,8 @@ export default function CreateModal({
             size="sm"
             colorScheme="red"
             position="absolute"
+            borderColor={"white"}
+            borderWidth={2}
             top={2}
             right={2}
             onClick={() => {
@@ -162,11 +164,13 @@ export default function CreateModal({
   // Define the JSX for the 'Continue (without submitting)' button in the modal
   const continueModalButton = (
     <Button
-      isDisabled={(activeStep === 0 && newAddedItem.name === "") ||
+      isDisabled={
+        (activeStep === 0 && newAddedItem.name === "") ||
         newAddedItem.description === "" ||
         (activeStep === 1 && newAddedItem.type === "") ||
         (activeStep === 2 && newAddedItem.itemdate === "") ||
-        (activeStep === 3 && uploadImg === "")}
+        (activeStep === 3 && uploadImg === "")
+      }
       variant={"solid"}
       colorScheme="blue"
       size="lg"
@@ -179,11 +183,13 @@ export default function CreateModal({
   // Define the JSX for the 'Continue (and submit)' button in the modal
   const submitModalButton = (
     <Button
-      isDisabled={uploadImg === upload ||
+      isDisabled={
+        uploadImg === upload ||
         newAddedItem.image === "" ||
         newAddedItem.type === "" ||
         newAddedItem.name === "" ||
-        newAddedItem.description === ""}
+        newAddedItem.description === ""
+      }
       variant={"solid"}
       type="submit"
       colorScheme="green"
@@ -207,7 +213,7 @@ export default function CreateModal({
         itemdate: e.toISOString().split("T")[0],
       }));
     },
-    [setNewAddedItem],
+    [setNewAddedItem]
   );
 
   // Define the callback function to change the item name
@@ -217,7 +223,7 @@ export default function CreateModal({
         ...prev,
         name: e.target.value,
       })),
-    [setNewAddedItem],
+    [setNewAddedItem]
   );
 
   // Define the callback function to change the item description
@@ -227,7 +233,7 @@ export default function CreateModal({
         ...prev,
         description: e.target.value,
       })),
-    [setNewAddedItem],
+    [setNewAddedItem]
   );
 
   // Define the callback function to change the item image
@@ -246,7 +252,7 @@ export default function CreateModal({
         alert("Image exceeds size limit of 10 MB");
       }
     },
-    [setNewAddedItem],
+    [setNewAddedItem]
   );
 
   return (

--- a/packages/web/src/components/CreateModal/components/ImageInput.jsx
+++ b/packages/web/src/components/CreateModal/components/ImageInput.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Flex, FormControl, Input } from "@chakra-ui/react";
+import { Box, Flex, FormControl, Heading, Input, Text } from "@chakra-ui/react";
 
 const ImageInput = (
     { handleItemImageChange, isLoading, loadingAnimation, uploadedImage },
@@ -13,23 +13,7 @@ const ImageInput = (
                 justifyContent="center"
             >
                 <Flex justifyContent="center" alignItems="center" gap={3}>
-                    <Input
-                        type="file"
-                        accept="image/*"
-                        multiple
-                        width="38%"
-                        sx={{
-                            "::file-selector-button": {
-                                height: 10,
-                                padding: 0,
-                                mr: 4,
-                                background: "none",
-                                border: "none",
-                                fontWeight: "bold",
-                            },
-                        }}
-                        onChange={handleItemImageChange}
-                    />
+                    <Dropzone handleItemImageChange={handleItemImageChange} />
                 </Flex>
                 {isLoading ? loadingAnimation : uploadedImage}
             </Flex>
@@ -38,3 +22,46 @@ const ImageInput = (
 };
 
 export default ImageInput;
+
+function Dropzone({ handleItemImageChange }) {
+    return (
+        <Box style={{ maxWidth: "md", width: "100%" }}>
+            <Box
+                style={{
+                    position: "relative",
+                    height: "12rem",
+                    cursor: "pointer",
+                    borderWidth: "2px",
+                    borderStyle: "dashed",
+                    borderColor: "#CBD5E0",
+                    borderRadius: "0.5rem",
+                    backgroundColor: "#111",
+                    color: "white",
+                    padding: "1.5rem",
+                    textAlign: "center",
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    justifyContent: "center"
+                }}
+            >
+                <Heading size="sm" style={{ marginTop: "1rem", color: "#CBD5E0" }}>
+                    Upload a file
+                </Heading>
+                <Text style={{ marginTop: "0.25rem", fontSize: "0.875rem", color: "#718096" }}>
+                    Drop your file here or click to select a file
+                </Text>
+                <input  
+                    type="file"
+                    style={{
+                        position: "absolute",
+                        inset: 0,
+                        cursor: "pointer",
+                        opacity: 0
+                    }}
+                    onChange={handleItemImageChange}
+                />
+            </Box>
+        </Box>
+    );
+}

--- a/packages/web/src/components/CreateModal/components/ImageInput.jsx
+++ b/packages/web/src/components/CreateModal/components/ImageInput.jsx
@@ -13,9 +13,13 @@ const ImageInput = (
                 justifyContent="center"
             >
                 <Flex justifyContent="center" alignItems="center" gap={3}>
-                    <Dropzone handleItemImageChange={handleItemImageChange} />
+                    {uploadedImage ? uploadedImage : (
+                        <Dropzone
+                            handleItemImageChange={handleItemImageChange}
+                            uploadedImage={uploadedImage}
+                        />
+                    )}
                 </Flex>
-                {isLoading ? loadingAnimation : uploadedImage}
             </Flex>
         </FormControl>
     );
@@ -25,39 +29,33 @@ export default ImageInput;
 
 function Dropzone({ handleItemImageChange }) {
     return (
-        <Box style={{ maxWidth: "md", width: "100%" }}>
+        <Box maxW={{ base: "100%", md: "md" }} w="100%">
             <Box
-                style={{
-                    position: "relative",
-                    height: "12rem",
-                    cursor: "pointer",
-                    borderWidth: "2px",
-                    borderStyle: "dashed",
-                    borderColor: "#CBD5E0",
-                    borderRadius: "0.5rem",
-                    backgroundColor: "#111",
-                    color: "white",
-                    padding: "1.5rem",
-                    textAlign: "center",
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    justifyContent: "center",
+                position="relative"
+                h={{ base: "10rem", md: "12rem" }}
+                cursor="pointer"
+                borderWidth="2px"
+                borderStyle="dashed"
+                borderColor="gray.300"
+                borderRadius="lg"
+                bg="gray.500"
+                color="gray.900"
+                p={{ base: "3", md: "6" }}
+                textAlign="center"
+                display="flex"
+                flexDirection="column"
+                alignItems="center"
+                justifyContent="center"
+                transition="all 0.2s"
+                _hover={{
+                    bg: "gray.100",
+                    borderColor: "gray.400",
                 }}
             >
-                <Heading
-                    size="sm"
-                    style={{ marginTop: "1rem", color: "#CBD5E0" }}
-                >
+                <Heading size="sm" mt="4" color="gray.600">
                     Upload a file
                 </Heading>
-                <Text
-                    style={{
-                        marginTop: "0.25rem",
-                        fontSize: "0.875rem",
-                        color: "#718096",
-                    }}
-                >
+                <Text mt="1" fontSize="sm" color="gray.700">
                     Drop your file here or click to select a file
                 </Text>
                 <input

--- a/packages/web/src/components/CreateModal/components/ImageInput.jsx
+++ b/packages/web/src/components/CreateModal/components/ImageInput.jsx
@@ -1,75 +1,86 @@
 import React from "react";
 import { Box, Flex, FormControl, Heading, Input, Text } from "@chakra-ui/react";
 
-const ImageInput = (
-    { handleItemImageChange, isLoading, loadingAnimation, uploadedImage },
-) => {
-    return (
-        <FormControl>
-            <Flex
-                gap={5}
-                alignItems="center"
-                flexDirection="column"
-                justifyContent="center"
-            >
-                <Flex justifyContent="center" alignItems="center" gap={3}>
-                    {uploadedImage ? uploadedImage : (
-                        <Dropzone
-                            handleItemImageChange={handleItemImageChange}
-                            uploadedImage={uploadedImage}
-                        />
-                    )}
-                </Flex>
-            </Flex>
-        </FormControl>
-    );
+const ImageInput = ({
+  handleItemImageChange,
+  isLoading,
+  loadingAnimation,
+  uploadedImage,
+}) => {
+  return (
+    <FormControl>
+      <Flex
+        gap={5}
+        alignItems="center"
+        flexDirection="column"
+        justifyContent="center"
+      >
+        <Flex justifyContent="center" alignItems="center" gap={3}>
+          {uploadedImage ? (
+            uploadedImage
+          ) : (
+            <Dropzone
+              handleItemImageChange={handleItemImageChange}
+              uploadedImage={uploadedImage}
+            />
+          )}
+        </Flex>
+      </Flex>
+    </FormControl>
+  );
 };
 
 export default ImageInput;
 
 function Dropzone({ handleItemImageChange }) {
-    return (
-        <Box maxW={{ base: "100%", md: "md" }} w="100%">
-            <Box
-                position="relative"
-                h={{ base: "10rem", md: "12rem" }}
-                cursor="pointer"
-                borderWidth="2px"
-                borderStyle="dashed"
-                borderColor="gray.300"
-                borderRadius="lg"
-                bg="gray.500"
-                color="gray.900"
-                p={{ base: "3", md: "6" }}
-                textAlign="center"
-                display="flex"
-                flexDirection="column"
-                alignItems="center"
-                justifyContent="center"
-                transition="all 0.2s"
-                _hover={{
-                    bg: "gray.100",
-                    borderColor: "gray.400",
-                }}
-            >
-                <Heading size="sm" mt="4" color="gray.600">
-                    Upload a file
-                </Heading>
-                <Text mt="1" fontSize="sm" color="gray.700">
-                    Drop your file here or click to select a file
-                </Text>
-                <input
-                    type="file"
-                    accept="image/*"
-                    style={{
-                        position: "absolute",
-                        inset: 0,
-                        cursor: "pointer",
-                        opacity: 0,
-                    }}
-                    onChange={handleItemImageChange}
-                />
-            </Box>
-        </Box>
-    );
+  return (
+    <Box
+      maxW={{ base: "100%", md: "md" }}
+      w="100%"
+      h={"md"}
+      alignSelf={"center"}
+    >
+      <Box
+        position="relative"
+        w={{ base: "sm", md: "md" }}
+        h={"md"}
+        cursor="pointer"
+        borderWidth="2px"
+        borderStyle="dashed"
+        borderColor="gray.300"
+        borderRadius="lg"
+        bg="gray.500"
+        color="gray.900"
+        p={{ base: "3", md: "6" }}
+        textAlign="center"
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        justifyContent="center"
+        transition="all 0.2s"
+        _hover={{
+          bg: "gray.100",
+          borderColor: "gray.400",
+        }}
+      >
+        <Heading size="sm" mt="4" color="gray.600">
+          Upload a file
+        </Heading>
+        <Text mt="1" fontSize="sm" color="gray.700">
+          Drop your file here or click to select a file
+        </Text>
+        <input
+          type="file"
+          accept="image/*"
+          style={{
+            position: "absolute",
+            inset: 0,
+            cursor: "pointer",
+            opacity: 0,
+          }}
+          onChange={handleItemImageChange}
+        />
+      </Box>
+    </Box>
+  );
 }

--- a/packages/web/src/components/CreateModal/components/ImageInput.jsx
+++ b/packages/web/src/components/CreateModal/components/ImageInput.jsx
@@ -42,22 +42,32 @@ function Dropzone({ handleItemImageChange }) {
                     display: "flex",
                     flexDirection: "column",
                     alignItems: "center",
-                    justifyContent: "center"
+                    justifyContent: "center",
                 }}
             >
-                <Heading size="sm" style={{ marginTop: "1rem", color: "#CBD5E0" }}>
+                <Heading
+                    size="sm"
+                    style={{ marginTop: "1rem", color: "#CBD5E0" }}
+                >
                     Upload a file
                 </Heading>
-                <Text style={{ marginTop: "0.25rem", fontSize: "0.875rem", color: "#718096" }}>
+                <Text
+                    style={{
+                        marginTop: "0.25rem",
+                        fontSize: "0.875rem",
+                        color: "#718096",
+                    }}
+                >
                     Drop your file here or click to select a file
                 </Text>
-                <input  
+                <input
                     type="file"
+                    accept="image/*"
                     style={{
                         position: "absolute",
                         inset: 0,
                         cursor: "pointer",
-                        opacity: 0
+                        opacity: 0,
                     }}
                     onChange={handleItemImageChange}
                 />


### PR DESCRIPTION
- Adding a way for drag and Drop for images
- Adding an X button to reomve images

Note: the frontend is tested while confirmation with backend hasnt been done though it should work since it doesnt change much but could be better
Would have liked to added:
1: Adding Optimistic Updates using [XHR](https://github.com/Priyansh4444/PowerpointScraper/blob/master/islands/Dropzone.tsx) (a loading bar of sorts) (I have an example of doing this using https://powerpoint-scraper.deno.dev/)
2: Making the UI  a bit bettter  (especially considering I feel like this does a lot of rerenders the way i am doing it)
3:  Wouldve liked to also use chakra 3.5's dropzone since it looks better but we are still on 2.6 and there is a lot of dependancy issues based on that :(

Hopefully will be able to do more this upcoming week
