### PR TITLE
Remove user existence check and only query top 3 users on leaderboard

### DIFF
--- a/packages/functions/src/routes/leaderboard.js
+++ b/packages/functions/src/routes/leaderboard.js
@@ -35,11 +35,11 @@ leaderboardRouter.post("/", async (req, res) => {
   }
 });
 
-// get all users on leaderboard (descending)
+// get top 3 users on leaderboard (descending)
 leaderboardRouter.get("/", async (req, res) => {
   try {
     const lbData = await client.query(
-      `SELECT * FROM ${leaderboardTable} ORDER BY points DESC`
+      `SELECT * FROM ${leaderboardTable} ORDER BY points DESC LIMIT 3`
     );
 
     res.json(lbData.rows);

--- a/packages/functions/src/routes/leaderboard.js
+++ b/packages/functions/src/routes/leaderboard.js
@@ -19,7 +19,7 @@ leaderboardRouter.post("/", async (req, res) => {
     );
 
     if (existingUser.rows.length > 0) {
-      return res.status(400).send("Email already exists in the leaderboard");
+      return res.status(201).send("Email already exists in the leaderboard");
     }
 
     // Insert the new email and points into the leaderboard

--- a/packages/web/src/components/Home/Home.jsx
+++ b/packages/web/src/components/Home/Home.jsx
@@ -252,7 +252,6 @@ export default function Home() {
         const config = {
           headers: {
             Authorization: `Bearer ${token}`,
-            "User-Email": user?.email,
           },
         };
 
@@ -271,8 +270,7 @@ export default function Home() {
         }
         // Fetch the leaderboard again after insertion
         const { data: updatedLeaderboardData } = await axios.get(
-          `${import.meta.env.VITE_REACT_APP_AWS_BACKEND_URL}/leaderboard`,
-          config
+          `${import.meta.env.VITE_REACT_APP_AWS_BACKEND_URL}/leaderboard/`,
         );
         setLeaderboard(
           updatedLeaderboardData.map((item) => ({ ...item, id: item.id }))

--- a/packages/web/src/components/Home/Home.jsx
+++ b/packages/web/src/components/Home/Home.jsx
@@ -255,41 +255,24 @@ export default function Home() {
             "User-Email": user?.email,
           },
         };
-        // Get email associated with item id
 
-        const { data: leaderboardData } = await axios.get(
+        // add user to leaderboard if they don't exist already
+        await axios.post(
           `${import.meta.env.VITE_REACT_APP_AWS_BACKEND_URL}/leaderboard/`,
+          {
+            email: user.email,
+            points: 5, // You can modify this as per your requirements
+          },
           config
         );
-
+        // Fetch the leaderboard again after insertion
+        const { data: updatedLeaderboardData } = await axios.get(
+          `${import.meta.env.VITE_REACT_APP_AWS_BACKEND_URL}/leaderboard`,
+          config
+        );
         setLeaderboard(
-          leaderboardData.map((item) => ({ ...item, id: item.id }))
+          updatedLeaderboardData.map((item) => ({ ...item, id: item.id }))
         );
-
-        // Check if the current user's email exists in the leaderboard
-        const userEmailExists = leaderboardData.some(
-          (entry) => entry.email === user?.email
-        );
-        // If it does not exist, add the user to the leaderboard
-        if (!userEmailExists && user) {
-          // added user to prevent race condition (user is undefined before auth resolves)
-          await axios.post(
-            `${import.meta.env.VITE_REACT_APP_AWS_BACKEND_URL}/leaderboard/`,
-            {
-              email: user.email,
-              points: 5, // You can modify this as per your requirements
-            },
-            config
-          );
-          // Fetch the leaderboard again after insertion
-          const { data: updatedLeaderboardData } = await axios.get(
-            `${import.meta.env.VITE_REACT_APP_AWS_BACKEND_URL}/leaderboard`,
-            config
-          );
-          setLeaderboard(
-            updatedLeaderboardData.map((item) => ({ ...item, id: item.id }))
-          );
-        }
       } catch (err) {
         console.log(err);
       } finally {

--- a/packages/web/src/components/Home/Home.jsx
+++ b/packages/web/src/components/Home/Home.jsx
@@ -251,20 +251,24 @@ export default function Home() {
         if (!token) return;
         const config = {
           headers: {
-            // Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${token}`,
             "User-Email": user?.email,
           },
         };
 
         // add user to leaderboard if they don't exist already
-        await axios.post(
-          `${import.meta.env.VITE_REACT_APP_AWS_BACKEND_URL}/leaderboard/`,
-          {
-            email: user.email,
-            points: 5, // You can modify this as per your requirements
-          },
-          config
-        );
+        try {
+          await axios.post(
+            `${import.meta.env.VITE_REACT_APP_AWS_BACKEND_URL}/leaderboard/`,
+            {
+              email: user.email,
+              points: 5, // You can modify this as per your requirements
+            },
+            config
+          );
+        } catch (error) {
+          console.log(error.response.data);
+        }
         // Fetch the leaderboard again after insertion
         const { data: updatedLeaderboardData } = await axios.get(
           `${import.meta.env.VITE_REACT_APP_AWS_BACKEND_URL}/leaderboard`,


### PR DESCRIPTION
Closes #115 
- On the home page, send leaderboard POST request without checking if user exists (POST request has check for user existence)
- Changed leaderboard GET request to only get top 3 users (avoid leaking all emails)